### PR TITLE
Add glob pattern configuration for hxml discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
 		"configuration": {
 			"title": "Haxe",
 			"properties": {
+				"haxe.hxmlPath": {
+					"scope": "resource",
+					"markdownDescription": "Global pattern to search for .hxml files.",
+					"default": "*.hxml",
+					"type": "string"
+				},
 				"haxe.executable": {
 					"scope": "resource",
 					"markdownDescription": "Path to the Haxe executable or an object containing a Haxe executable configuration",

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
 		"configuration": {
 			"title": "Haxe",
 			"properties": {
-				"haxe.hxmlPath": {
+				"haxe.hxmlGlobPattern": {
 					"scope": "resource",
-					"markdownDescription": "Global pattern to search for .hxml files.",
+					"markdownDescription": "Glob pattern to search for .hxml files in the workspace",
 					"default": "*.hxml",
 					"type": "string"
 				},

--- a/src/vshaxe/HxmlDiscovery.hx
+++ b/src/vshaxe/HxmlDiscovery.hx
@@ -22,7 +22,7 @@ class HxmlDiscovery {
 		didChangeFilesEmitter = new EventEmitter();
 		files = mementos.getDefault(folder, DiscoveredFilesKey, []);
 
-		final globConfig = workspace.getConfiguration('haxe').get('hxmlPath');
+		final globConfig = workspace.getConfiguration('haxe').get('hxmlGlobPattern');
 		final globPattern = globConfig == null ? '*.hxml' : globConfig;
 
 		final pattern = new RelativePattern(folder, globPattern);

--- a/src/vshaxe/HxmlDiscovery.hx
+++ b/src/vshaxe/HxmlDiscovery.hx
@@ -22,7 +22,10 @@ class HxmlDiscovery {
 		didChangeFilesEmitter = new EventEmitter();
 		files = mementos.getDefault(folder, DiscoveredFilesKey, []);
 
-		final pattern = new RelativePattern(folder, "*.hxml");
+		final globConfig = workspace.getConfiguration('haxe').get('hxmlPath');
+		final globPattern = globConfig == null ? '*.hxml' : globConfig;
+
+		final pattern = new RelativePattern(folder, globPattern);
 		fileWatcher = workspace.createFileSystemWatcher(pattern, false, true, false);
 		fileWatcher.onDidCreate(uri -> {
 			files.push(pathRelativeToRoot(uri));


### PR DESCRIPTION
Allows changing the glob pattern for auto-discovery of .hxml files in your project.

![image](https://user-images.githubusercontent.com/14813394/92143865-3d04a200-edec-11ea-8000-2059875f2055.png)

![image](https://user-images.githubusercontent.com/14813394/92143910-4f7edb80-edec-11ea-9edc-d5e983e75fd6.png)

